### PR TITLE
task: export-pdf-png-and-both

### DIFF
--- a/figures/savefig_tight.m
+++ b/figures/savefig_tight.m
@@ -1,25 +1,41 @@
-function savefig_tight(h,outfilename)
-%SAVEFIG_TIGHT exports narrow margin figure as PDF file.
-%   SAVEFIG_TIGHT(h, outfilename) generates a PDF file from a figure h with
-%   a string outfilename. 
+function savefig_tight(h,outfilename,format)
+%SAVEFIG_TIGHT exports narrow margin figure as file.
+%   SAVEFIG_TIGHT(h, outfilename) generates a figure as a specified file format
+%  from a figure h with a string outfilename. 
 %
 % INPUTS: 
 %       h : figure
-%       outfilename : a string to name the exported PDF file
+%       outfilename : a string to name the exported file
+%       format : File format ('pdf', 'png', 'both')
 % OUTPUTS:
 %       none
 % EXAMPLE:
-%       h = figure;
-%       plot(1:10,1:10);
-%       axis tight;
-%       savefig_tight(h,'myfigure');
+%      h = figure;
+%      plot(1:10,1:10);
+%      axis tight;
+%      savefig_tight(h,'myfigure','png');
 %
 %   See also figure, print
 % 
 %HISTORY:
 % 2021/05/03 - Lucas Abdalah.
-    set(h,'Units','Inches');
-    pos = get(h,'Position');
-    set(h,'PaperPositionMode','Auto','PaperUnits','Inches','PaperSize',[pos(3), pos(4)]);
-    print(outfilename ,'-dpdf','-fillpage');
+% 2022/05/17 - Lucas Abdalah.
+%
+
+set(h,'Units','Inches');
+pos = get(h,'Position');
+set(h,'PaperPositionMode','Auto','PaperUnits','Inches','PaperSize',[pos(3), pos(4)]);
+
+switch format
+    case 'pdf'
+        print(outfilename ,'-dpdf','-fillpage');
+    case 'png'
+        print(outfilename ,'-dpng');
+    case 'both'
+        print(outfilename ,'-dpdf','-fillpage');
+        print(outfilename ,'-dpng');
+    otherwise
+        error('Error. \nInput unkown. Format variable must be a string containing an available format:\n"pdf"\n"png"')
+end
+
 end


### PR DESCRIPTION
Now the function figures/`savefig_tight.`m is able to export PDF, PNG or both simultaneously.